### PR TITLE
:charge_fee_to parameter doesn't belong in Remit::FundPrepaid::Request

### DIFF
--- a/lib/remit/operations/fund_prepaid.rb
+++ b/lib/remit/operations/fund_prepaid.rb
@@ -7,7 +7,6 @@ module Remit
       parameter :transaction_ids
       parameter :caller_description
       parameter :caller_reference, :required => true
-      parameter :charge_fee_to, :required => true
       parameter :funding_amount, :type => Remit::RequestTypes::Amount, :required => true
       parameter :prepaid_instrument_id, :required => true
       parameter :recipient_reference


### PR DESCRIPTION
I'm not sure if it's because Amazon changed their schema, but FundPrepaid doesn't work with the :charge_fee_to parameter required.

Micah
